### PR TITLE
Fix /etc/apimon directory permissions for epmon

### DIFF
--- a/roles/epmon/tasks/main.yml
+++ b/roles/epmon/tasks/main.yml
@@ -50,6 +50,7 @@
     state: "directory"
     owner: "{{ epmon_os_user }}"
     group: "{{ epmon_os_group }}"
+    mode: "{{ item.mode | default(omit) }}"
   loop:
     - {dest: "{{ epmon_config_dir }}", mode: "0755"}
 


### PR DESCRIPTION
we are even passing desired directory permissions of the directory but
not really setting them for epmon
