### PR TITLE
forcely bind to host network

### DIFF
--- a/roles/executor/templates/apimon-executor.service.j2
+++ b/roles/executor/templates/apimon-executor.service.j2
@@ -16,6 +16,7 @@ ExecStartPre=-{{ container_runtime }} rm "{{ executor_container_name }}"
 ExecStart={{ container_runtime }} run \
   --name "{{ executor_container_name }}" \
   --hostname={{ ansible_hostname }} \
+  --network host \
 {% if container_command == 'podman' %}
   --log-opt=path=/dev/null \
 {% endif %}


### PR DESCRIPTION
With docker on some distros executor lands on the "null" network without access 